### PR TITLE
Support sampling in `honeycomb-rails` (either an Integer or a Proc)

### DIFF
--- a/lib/honeycomb-rails/config.rb
+++ b/lib/honeycomb-rails/config.rb
@@ -11,6 +11,7 @@ module HoneycombRails
       @logger = Rails.logger
       @capture_exceptions = true
       @capture_exception_backtraces = true
+      @sample_rate = 1
     end
 
     # Whether to record flash messages (default: true).
@@ -47,6 +48,19 @@ module HoneycombRails
 
     # The Honeycomb write key for your team (must be specified).
     attr_accessor :writekey
+
+    # If set, determines how to record the sample rate for a given Honeycomb
+    # event. (default: 1, do not sample)
+    #
+    # Valid values:
+    # * Integer - sample Honeycomb events at a constant rate
+    # * 1 or lower - disable sampling on this dataset; capture all events
+    # * TODO: :rails - default Rails dynamic sampling?
+    #
+    # You can also pass a Proc, which will be called with the current controller
+    # instance during each request, and which should return a sample rate for
+    # the request in question.
+    attr_accessor :sample_rate
 
     # If set to true, captures exception class name / message along with Rails
     # request events. (default: true)

--- a/lib/honeycomb-rails/subscribers/process_action.rb
+++ b/lib/honeycomb-rails/subscribers/process_action.rb
@@ -37,7 +37,19 @@ module HoneycombRails
           data.merge!(event.payload[Constants::EVENT_METADATA_KEY])
         end
 
-        @libhoney.send_now(data)
+        honeycomb_event = @libhoney.event
+        honeycomb_event.add(data)
+
+        case HoneycombRails.config.sample_rate
+        when Proc
+          honeycomb_event.sample_rate = HoneycombRails.config.sample_rate.call(event.payload)
+        when Integer
+          if HoneycombRails.config.sample_rate > 1
+            honeycomb_event.sample_rate = HoneycombRails.config.sample_rate
+          end
+        end
+
+        honeycomb_event.send
       end
     end
   end


### PR DESCRIPTION
TODO: add some magic `:rails` dynamic sampling support?

Adding basic support to either sample at a constant rate or to pass in a Proc defining the sample rate based on the event payload. Intent is to allow for **some** configuration of the sample rate at the `honeycomb-rails` level, since we don't actually expose the base `@libhoney` variable anywhere in the gem.