### PR TITLE
Support optionally capturing exception (class, message, cleaned backtrace)

### DIFF
--- a/lib/honeycomb-rails/config.rb
+++ b/lib/honeycomb-rails/config.rb
@@ -9,7 +9,7 @@ module HoneycombRails
       @record_flash = true
       @record_user = :detect
       @logger = Rails.logger
-      @capture_exceptions = false
+      @capture_exceptions = true
     end
 
     # Whether to record flash messages (default: true).
@@ -48,7 +48,7 @@ module HoneycombRails
     attr_accessor :writekey
 
     # If set to true, captures exception class name / message / backtrace
-    # source along with Rails request events. (default: false)
+    # source along with Rails request events. (default: true)
     attr_accessor :capture_exceptions
   end
 

--- a/lib/honeycomb-rails/config.rb
+++ b/lib/honeycomb-rails/config.rb
@@ -9,6 +9,7 @@ module HoneycombRails
       @record_flash = true
       @record_user = :detect
       @logger = Rails.logger
+      @capture_exceptions = false
     end
 
     # Whether to record flash messages (default: true).
@@ -45,6 +46,10 @@ module HoneycombRails
 
     # The Honeycomb write key for your team (must be specified).
     attr_accessor :writekey
+
+    # If set to true, captures exception class name / message / backtrace
+    # source along with Rails request events. (default: false)
+    attr_accessor :capture_exceptions
   end
 
   class << self

--- a/lib/honeycomb-rails/config.rb
+++ b/lib/honeycomb-rails/config.rb
@@ -10,6 +10,7 @@ module HoneycombRails
       @record_user = :detect
       @logger = Rails.logger
       @capture_exceptions = true
+      @capture_exception_backtraces = true
     end
 
     # Whether to record flash messages (default: true).
@@ -47,9 +48,13 @@ module HoneycombRails
     # The Honeycomb write key for your team (must be specified).
     attr_accessor :writekey
 
-    # If set to true, captures exception class name / message / backtrace
-    # source along with Rails request events. (default: true)
+    # If set to true, captures exception class name / message along with Rails
+    # request events. (default: true)
     attr_accessor :capture_exceptions
+
+    # If set to true, captures backtraces when capturing exception metadata.
+    # No-op if capture_exceptions is false. (default: true)
+    attr_accessor :capture_exception_backtraces
   end
 
   class << self

--- a/lib/honeycomb-rails/extensions/action_controller.rb
+++ b/lib/honeycomb-rails/extensions/action_controller.rb
@@ -25,22 +25,6 @@ module HoneycombRails
         # @return [Hash<String=>Any>]
         attr_reader :honeycomb_metadata
       end
-
-      module InstanceCaptureExceptionsFilters
-        def self.included(controller_class)
-          controller_class.around_action do |base, block|
-            begin
-              block.call
-            rescue Exception => exception
-              honeycomb_metadata[:exception_class] = exception.class.to_s
-              honeycomb_metadata[:exception_message] = exception.message
-              honeycomb_metadata[:exception_source] = Rails.backtrace_cleaner.clean(exception.backtrace)
-
-              raise
-            end
-          end
-        end
-      end
     end
   end
 end

--- a/lib/honeycomb-rails/extensions/action_controller.rb
+++ b/lib/honeycomb-rails/extensions/action_controller.rb
@@ -25,6 +25,22 @@ module HoneycombRails
         # @return [Hash<String=>Any>]
         attr_reader :honeycomb_metadata
       end
+
+      module InstanceCaptureExceptionsFilters
+        def self.included(controller_class)
+          controller_class.around_action do |base, block|
+            begin
+              block.call
+            rescue Exception => exception
+              honeycomb_metadata[:exception_class] = exception.class.to_s
+              honeycomb_metadata[:exception_message] = exception.message
+              honeycomb_metadata[:exception_source] = Rails.backtrace_cleaner.clean(exception.backtrace)
+
+              raise
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/lib/honeycomb-rails/overrides/action_controller_instrumentation.rb
+++ b/lib/honeycomb-rails/overrides/action_controller_instrumentation.rb
@@ -65,5 +65,22 @@ module HoneycombRails
         end
       end
     end
+    module ActionControllerFilters
+      def self.included(controller_class)
+        controller_class.around_action :honeycomb_attach_exception_metadata
+      end
+
+      def honeycomb_attach_exception_metadata
+        begin
+          yield
+        rescue Exception => exception
+          honeycomb_metadata[:exception_class] = exception.class.to_s
+          honeycomb_metadata[:exception_message] = exception.message
+          honeycomb_metadata[:exception_source] = Rails.backtrace_cleaner.clean(exception.backtrace)
+
+          raise
+        end
+      end
+    end
   end
 end

--- a/lib/honeycomb-rails/overrides/action_controller_instrumentation.rb
+++ b/lib/honeycomb-rails/overrides/action_controller_instrumentation.rb
@@ -80,7 +80,7 @@ module HoneycombRails
             honeycomb_metadata[:exception_source] = Rails.backtrace_cleaner.clean(exception.backtrace)
           end
 
-          raise exception
+          raise
         end
       end
     end

--- a/lib/honeycomb-rails/overrides/action_controller_instrumentation.rb
+++ b/lib/honeycomb-rails/overrides/action_controller_instrumentation.rb
@@ -76,7 +76,9 @@ module HoneycombRails
         rescue Exception => exception
           honeycomb_metadata[:exception_class] = exception.class.to_s
           honeycomb_metadata[:exception_message] = exception.message
-          honeycomb_metadata[:exception_source] = Rails.backtrace_cleaner.clean(exception.backtrace)
+          if HoneycombRails.config.capture_exception_backtraces
+            honeycomb_metadata[:exception_source] = Rails.backtrace_cleaner.clean(exception.backtrace)
+          end
 
           raise
         end

--- a/lib/honeycomb-rails/overrides/action_controller_instrumentation.rb
+++ b/lib/honeycomb-rails/overrides/action_controller_instrumentation.rb
@@ -73,14 +73,14 @@ module HoneycombRails
       def honeycomb_attach_exception_metadata
         begin
           yield
-        rescue Exception => exception
+        rescue StandardError => exception
           honeycomb_metadata[:exception_class] = exception.class.to_s
           honeycomb_metadata[:exception_message] = exception.message
           if HoneycombRails.config.capture_exception_backtraces
             honeycomb_metadata[:exception_source] = Rails.backtrace_cleaner.clean(exception.backtrace)
           end
 
-          raise
+          raise exception
         end
       end
     end

--- a/lib/honeycomb-rails/railtie.rb
+++ b/lib/honeycomb-rails/railtie.rb
@@ -21,7 +21,7 @@ module HoneycombRails
       @libhoney = Libhoney::Client.new(writekey: writekey)
 
       if HoneycombRails.config.capture_exceptions
-        ::ActionController::Base.include(Extensions::ActionController::InstanceCaptureExceptionsFilters)
+        ::ActionController::Base.include(Overrides::ActionControllerFilters)
       end
     end
 

--- a/lib/honeycomb-rails/railtie.rb
+++ b/lib/honeycomb-rails/railtie.rb
@@ -19,6 +19,10 @@ module HoneycombRails
     config.after_initialize do
       writekey = HoneycombRails.config.writekey
       @libhoney = Libhoney::Client.new(writekey: writekey)
+
+      if HoneycombRails.config.capture_exceptions
+        ::ActionController::Base.include(Extensions::ActionController::InstanceCaptureExceptionsFilters)
+      end
     end
 
     config.after_initialize do

--- a/spec/overrides/action_controller_instrumentation_spec.rb
+++ b/spec/overrides/action_controller_instrumentation_spec.rb
@@ -83,13 +83,29 @@ RSpec.describe HoneycombRails::Overrides::ActionControllerInstrumentation do
         subject.honeycomb_attach_exception_metadata do
             raise RuntimeError, 'kaboom!'
         end
-      rescue Exception => e
+      rescue Exception
         caught = true
       end
 
       expect(caught).to eq true
       expect(subject.honeycomb_metadata).to include(exception_class: 'RuntimeError')
       expect(subject.honeycomb_metadata).to include(exception_message: 'kaboom!')
+      expect(subject.honeycomb_metadata).to include(:exception_source)
+    end
+
+    it 'should ignore backtraces if configured to do so' do
+      HoneycombRails.config.capture_exception_backtraces = false
+
+      begin
+        subject.honeycomb_attach_exception_metadata do
+            raise RuntimeError, 'kaboom!'
+        end
+      rescue Exception
+      end
+
+      expect(subject.honeycomb_metadata).to include(exception_class: 'RuntimeError')
+      expect(subject.honeycomb_metadata).to include(exception_message: 'kaboom!')
+      expect(subject.honeycomb_metadata).to_not include(:exception_source)
     end
   end
 

--- a/spec/overrides/action_controller_instrumentation_spec.rb
+++ b/spec/overrides/action_controller_instrumentation_spec.rb
@@ -81,9 +81,9 @@ RSpec.describe HoneycombRails::Overrides::ActionControllerInstrumentation do
       caught = false
       begin
         subject.honeycomb_attach_exception_metadata do
-            raise RuntimeError, 'kaboom!'
+          raise RuntimeError, 'kaboom!'
         end
-      rescue Exception
+      rescue StandardError
         caught = true
       end
 
@@ -98,9 +98,9 @@ RSpec.describe HoneycombRails::Overrides::ActionControllerInstrumentation do
 
       begin
         subject.honeycomb_attach_exception_metadata do
-            raise RuntimeError, 'kaboom!'
+          raise RuntimeError, 'kaboom!'
         end
-      rescue Exception
+      rescue StandardError
       end
 
       expect(subject.honeycomb_metadata).to include(exception_class: 'RuntimeError')


### PR DESCRIPTION
For folks who're interested in also seeing exceptions alongside their Rails request data. Intended for queries `WHERE exception_class exists` or for breaking down by `exception_class` / `exception_message` in Honeycomb itself.

(Note: so much dogscience it's not even funny.)

cc @samstokes 