### PR TITLE
Support pre-Rails 5.x `sql.active_record` notifications

### DIFF
--- a/lib/honeycomb-rails/subscribers/active_record.rb
+++ b/lib/honeycomb-rails/subscribers/active_record.rb
@@ -20,7 +20,11 @@ module HoneycombRails
         data = event.payload.slice(:name, :connection_id)
         data[:sql] = event.payload[:sql].strip
         event.payload[:binds].each do |b|
-          data["bind_#{ b.name }".to_sym] = b.value
+          if b.is_a?(Array)
+            data["bind_#{ b[0].name }".to_sym] = b[1]
+          elsif b.is_a?(Object)
+            data["bind_#{ b.name }".to_sym] = b.value
+          end
         end
         data[:duration] = event.duration
 

--- a/lib/honeycomb-rails/subscribers/active_record.rb
+++ b/lib/honeycomb-rails/subscribers/active_record.rb
@@ -20,9 +20,10 @@ module HoneycombRails
         data = event.payload.slice(:name, :connection_id)
         data[:sql] = event.payload[:sql].strip
         event.payload[:binds].each do |b|
-          if b.is_a?(Array)
+          case b
+          when Array
             data["bind_#{ b[0].name }".to_sym] = b[1]
-          elsif b.is_a?(Object)
+          else
             data["bind_#{ b.name }".to_sym] = b.value
           end
         end


### PR DESCRIPTION
... and be tolerant of `ActiveSupport::Notifications::Event`s that come
in with their `binds` containing an array of arrays rather than an array
of objects.

Looks like Rails 4.2.x has their `event.payload[:binds]` contain a list
of `[ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter::Column, value]`
pairs rather embedding the `value` in the `Column` object.

Fixes #14 .