### PR TITLE
Lazily initialize @honeycomb_metadata instead of relying on before_action

### DIFF
--- a/lib/honeycomb-rails/extensions/action_controller.rb
+++ b/lib/honeycomb-rails/extensions/action_controller.rb
@@ -2,18 +2,6 @@ module HoneycombRails
   module Extensions
     module ActionController
       module InstanceMethods
-        def self.included(controller_class)
-          super
-
-          controller_class.before_action do
-            honeycomb_initialize
-          end
-        end
-
-        def honeycomb_initialize
-          @honeycomb_metadata = {}
-        end
-
         # Hash of metadata to be added to the event we will send to Honeycomb
         # for the current request.
         #
@@ -23,7 +11,9 @@ module HoneycombRails
         #     honeycomb_metadata[:num_posts] = @posts.size
         #
         # @return [Hash<String=>Any>]
-        attr_reader :honeycomb_metadata
+        def honeycomb_metadata
+          @honeycomb_metadata ||= {}
+        end
       end
     end
   end


### PR DESCRIPTION
Asked @samstokes about the rationale behind the `self.included`/`before_action` approach for `honeycomb_initialize` and he responded with:

> I can't remember but it was probably either a thorny initialization order workaround or an innocuous stylistic choice

Tests pass and manual QA seems to work just fine (with Devise detection and otherwise), so chalking up to the latter for now.

Fixes #12.