### PR TITLE
Revert #16 and be slightly more tolerant of uninitialized `honeycomb_metadata`

### DIFF
--- a/lib/honeycomb-rails/extensions/action_controller.rb
+++ b/lib/honeycomb-rails/extensions/action_controller.rb
@@ -2,6 +2,18 @@ module HoneycombRails
   module Extensions
     module ActionController
       module InstanceMethods
+        def self.included(controller_class)
+          super
+
+          controller_class.before_action do
+            honeycomb_initialize
+          end
+        end
+
+        def honeycomb_initialize
+          @honeycomb_metadata = {}
+        end
+
         # Hash of metadata to be added to the event we will send to Honeycomb
         # for the current request.
         #
@@ -11,9 +23,7 @@ module HoneycombRails
         #     honeycomb_metadata[:num_posts] = @posts.size
         #
         # @return [Hash<String=>Any>]
-        def honeycomb_metadata
-          @honeycomb_metadata ||= {}
-        end
+        attr_reader :honeycomb_metadata
       end
     end
   end

--- a/lib/honeycomb-rails/overrides/action_controller_instrumentation.rb
+++ b/lib/honeycomb-rails/overrides/action_controller_instrumentation.rb
@@ -7,7 +7,7 @@ module HoneycombRails
       def append_info_to_payload(payload)
         super
 
-        metadata = honeycomb_metadata
+        metadata = honeycomb_metadata || {}
 
         metadata.merge!(honeycomb_user_metadata)
 


### PR DESCRIPTION
Despite its ability to fix #12, turns out #16 was the wrong knee-jerk reaction.

Reproducing / conjuring the right Rails fu to construct a test for this particular case is beyond my current Rails ability/time at the moment, so... this PR reverts #16 (but introduces a `|| {}` check to try and address the issue faced in #12 as well). Consider this a stopgap measure until #17 can be properly addressed.