### PR TITLE
Revamp exception reporting to fix missing status code

### DIFF
--- a/lib/honeycomb-rails/overrides/action_controller_instrumentation.rb
+++ b/lib/honeycomb-rails/overrides/action_controller_instrumentation.rb
@@ -81,24 +81,5 @@ module HoneycombRails
         end
       end
     end
-    module ActionControllerFilters
-      def self.included(controller_class)
-        controller_class.around_action :honeycomb_attach_exception_metadata
-      end
-
-      def honeycomb_attach_exception_metadata
-        begin
-          yield
-        rescue StandardError => exception
-          honeycomb_metadata[:exception_class] = exception.class.to_s
-          honeycomb_metadata[:exception_message] = exception.message
-          if HoneycombRails.config.capture_exception_backtraces
-            honeycomb_metadata[:exception_source] = Rails.backtrace_cleaner.clean(exception.backtrace)
-          end
-
-          raise
-        end
-      end
-    end
   end
 end

--- a/lib/honeycomb-rails/railtie.rb
+++ b/lib/honeycomb-rails/railtie.rb
@@ -28,10 +28,6 @@ module HoneycombRails
         writekey: writekey,
         user_agent_addition: HoneycombRails::USER_AGENT_SUFFIX,
       )
-
-      if HoneycombRails.config.capture_exceptions
-        ::ActionController::Base.include(Overrides::ActionControllerFilters)
-      end
     end
 
     config.after_initialize do

--- a/spec/overrides/action_controller_instrumentation_spec.rb
+++ b/spec/overrides/action_controller_instrumentation_spec.rb
@@ -19,9 +19,6 @@ RSpec.describe HoneycombRails::Overrides::ActionControllerInstrumentation do
   class FakeController
     attr_reader :flash, :honeycomb_metadata, :logger
 
-    # Noop so we can test honeycomb_attach_exception_metadata in peace
-    def self.around_action(*args); end
-
     def initialize
       @honeycomb_metadata = {}
       @flash = {}
@@ -30,7 +27,6 @@ RSpec.describe HoneycombRails::Overrides::ActionControllerInstrumentation do
 
     include FakeInstrumentation
     include HoneycombRails::Overrides::ActionControllerInstrumentation
-    include HoneycombRails::Overrides::ActionControllerFilters
   end
   class FakeAuthenticatedController < FakeController
     # Devise-like #current_user method
@@ -79,39 +75,6 @@ RSpec.describe HoneycombRails::Overrides::ActionControllerInstrumentation do
 
     expect(payload).to include(:honeycomb_metadata)
     expect(payload[:honeycomb_metadata]).to include(flash_notice: 'Fired ze missiles.')
-  end
-
-  describe 'when capturing exceptions by default' do
-    it 'should captures the exception metadata' do
-      caught = false
-      begin
-        subject.honeycomb_attach_exception_metadata do
-          raise RuntimeError, 'kaboom!'
-        end
-      rescue StandardError
-        caught = true
-      end
-
-      expect(caught).to eq true
-      expect(subject.honeycomb_metadata).to include(exception_class: 'RuntimeError')
-      expect(subject.honeycomb_metadata).to include(exception_message: 'kaboom!')
-      expect(subject.honeycomb_metadata).to include(:exception_source)
-    end
-
-    it 'should ignore backtraces if configured to do so' do
-      HoneycombRails.config.capture_exception_backtraces = false
-
-      begin
-        subject.honeycomb_attach_exception_metadata do
-          raise RuntimeError, 'kaboom!'
-        end
-      rescue StandardError
-      end
-
-      expect(subject.honeycomb_metadata).to include(exception_class: 'RuntimeError')
-      expect(subject.honeycomb_metadata).to include(exception_message: 'kaboom!')
-      expect(subject.honeycomb_metadata).to_not include(:exception_source)
-    end
   end
 
   describe 'if config.record_flash is false' do


### PR DESCRIPTION
This moves the exception reporting out of an `around_action` filter on the controller and into `Subscribers::ProcessAction`, since the exception info is already being captured in the `ActiveSupport::Notifications` payload.

Besides just moving code around for fun, this lets us fix the "missing status code" issue (#11) closer to where it occurs. (The "`status` is nil if an exception occurred" issue appears to be a bug in ActiveSupport::Notifications, since the standard Rails logging also
[handles this case explicitly](https://github.com/rails/rails/blob/37b373a8d2a1cd132bbde51cd5a3abd4ecee433b/actionpack/lib/action_controller/log_subscriber.rb#L25).

The fix could live anywhere, but this makes it clearer what we're working around, so we don't need to bring along this workaround if we decide to move the logic somewhere else (e.g. a Rack middleware).

It also simplifies the tests, and probably removes a small amount of overhead due to getting rid of the around_filter.