### PR TITLE
Add integration tests and test on multiple Rails versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-Gemfile.lock
+Gemfile*.lock
 spec/examples.txt
 doc
 .yardoc

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Gemfile*.lock
 spec/examples.txt
 doc
 .yardoc
+log/test.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ rvm:
   - 2.2
   - 2.3
   - 2.4
+gemfile:
+  - Gemfile
+  - Gemfile.rails3.rb
+  - Gemfile.rails4.rb
 deploy:
   provider: rubygems
   api_key:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source 'https://rubygems.org'
 
 gemspec
+
+# pull in newer libhoney just for testing, since we need TestClient#reset
+gem 'libhoney', '>= 1.5.1'

--- a/Gemfile.rails3.rb
+++ b/Gemfile.rails3.rb
@@ -6,3 +6,4 @@ gemspec
 gem 'libhoney', '>= 1.5.1'
 
 gem 'rails', '< 4'
+gem 'test-unit', '~> 3.0'

--- a/Gemfile.rails3.rb
+++ b/Gemfile.rails3.rb
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gemspec
+
+# pull in newer libhoney just for testing, since we need TestClient#reset
+gem 'libhoney', '>= 1.5.1'
+
+gem 'rails', '< 4'

--- a/Gemfile.rails4.rb
+++ b/Gemfile.rails4.rb
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gemspec
+
+# pull in newer libhoney just for testing, since we need TestClient#reset
+gem 'libhoney', '>= 1.5.1'
+
+gem 'rails', '< 5'

--- a/honeycomb-rails.gemspec
+++ b/honeycomb-rails.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'bump'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'rspec-rails'
   gem.add_development_dependency 'yard'
 
 

--- a/lib/honeycomb-rails/config.rb
+++ b/lib/honeycomb-rails/config.rb
@@ -38,6 +38,11 @@ module HoneycombRails
     # about the current user.
     attr_accessor :record_user
 
+    # Override the default Libhoney::Client used to send events to Honeycomb.
+    # If this is specified, {#writekey} will be ignored.
+    # @api private
+    attr_accessor :client
+
     # Send request events to the Honeycomb dataset with this name (default:
     # 'rails'). Set to nil or an empty string to disable.
     attr_accessor :dataset

--- a/lib/honeycomb-rails/extensions/action_controller.rb
+++ b/lib/honeycomb-rails/extensions/action_controller.rb
@@ -5,8 +5,17 @@ module HoneycombRails
         def self.included(controller_class)
           super
 
-          controller_class.before_action do
+          install_before_filter!(controller_class) do
             honeycomb_initialize
+          end
+        end
+
+        def self.install_before_filter!(controller_class, &block)
+          raise ArgumentError unless block_given?
+          if ::Rails::VERSION::MAJOR < 4
+            controller_class.before_filter(&block)
+          else
+            controller_class.before_action(&block)
           end
         end
 

--- a/lib/honeycomb-rails/railtie.rb
+++ b/lib/honeycomb-rails/railtie.rb
@@ -19,15 +19,17 @@ module HoneycombRails
     config.after_initialize do
       HoneycombRails.config.logger ||= ::Rails.logger
 
-      writekey = HoneycombRails.config.writekey
-      if writekey.blank?
-        HoneycombRails.config.logger.warn("No write key defined! (Check your config's `writekey` value in config/initializers/honeycomb.rb) No events will be sent to Honeycomb.")
-      end
+      @libhoney = HoneycombRails.config.client || begin
+        writekey = HoneycombRails.config.writekey
+        if writekey.blank?
+          HoneycombRails.config.logger.warn("No write key defined! (Check your config's `writekey` value in config/initializers/honeycomb.rb) No events will be sent to Honeycomb.")
+        end
 
-      @libhoney = Libhoney::Client.new(
-        writekey: writekey,
-        user_agent_addition: HoneycombRails::USER_AGENT_SUFFIX,
-      )
+        Libhoney::Client.new(
+          writekey: writekey,
+          user_agent_addition: HoneycombRails::USER_AGENT_SUFFIX,
+        )
+      end
     end
 
     config.after_initialize do

--- a/spec/integration/instrumented_app_spec.rb
+++ b/spec/integration/instrumented_app_spec.rb
@@ -38,7 +38,11 @@ RSpec.describe 'instrumented Rails app', integration: true, type: :request do
         exception_message: 'kaboom!',
         status: 500,
       )
-      expect(event.data[:exception_source]).to be_an Array
+
+      if Rails::VERSION::MAJOR > 4
+        # we only support capturing exception_source on Rails 5+
+        expect(event.data[:exception_source]).to be_an Array
+      end
     end
 
   end

--- a/spec/integration/instrumented_app_spec.rb
+++ b/spec/integration/instrumented_app_spec.rb
@@ -1,0 +1,61 @@
+RSpec.describe 'instrumented Rails app', integration: true, type: :request do
+  before :all { TestApp.initialize! }
+  after :all { HoneycombRails.reset_config_to_default! }
+
+  after { HoneycombRails.config.client.reset }
+
+  def emitted_event
+    events = HoneycombRails.config.client.events
+    expect(events.size).to eq(1)
+    events[0]
+  end
+
+  describe 'default configuration' do
+
+    it 'sends events for each successful request' do
+      get '/hello'
+
+      expect(response.status).to eq(200)
+
+      event = emitted_event
+      expect(event.data).to include(
+        controller: HelloController.name,
+        action: 'show',
+        method: 'GET',
+        path: '/hello',
+        status: 200,
+      )
+    end
+
+    it 'sends events for requests we failed to handle, recording exception details' do
+      get '/explode'
+
+      expect(response.status).to eq(500)
+
+      event = emitted_event
+      expect(event.data).to include(
+        exception_class: HelloController::Explosion.name,
+        exception_message: 'kaboom!',
+        status: 500,
+      )
+      expect(event.data[:exception_source]).to be_an Array
+    end
+
+  end
+
+  describe 'with config.capture_exceptions = false' do
+    before { HoneycombRails.config.capture_exceptions = false }
+    after { HoneycombRails.config.capture_exceptions = true }
+
+    it 'sends events for requests we failed to handle, but omits exception details' do
+      get '/explode'
+
+      expect(response.status).to eq(500)
+
+      event = emitted_event
+      expect(event.data).to include(status: 500)
+      expect(event.data).to_not include(:exception_class, :exception_message, :exception_source)
+    end
+
+  end
+end

--- a/spec/integration/instrumented_app_spec.rb
+++ b/spec/integration/instrumented_app_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'instrumented Rails app', integration: true, type: :request do
+RSpec.describe "instrumented Rails #{Rails::VERSION::MAJOR} app", integration: true, type: :request do
   before(:all) { TestApp.initialize! }
   after(:all) { HoneycombRails.reset_config_to_default! }
 

--- a/spec/integration/instrumented_app_spec.rb
+++ b/spec/integration/instrumented_app_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe 'instrumented Rails app', integration: true, type: :request do
-  before :all { TestApp.initialize! }
-  after :all { HoneycombRails.reset_config_to_default! }
+  before(:all) { TestApp.initialize! }
+  after(:all) { HoneycombRails.reset_config_to_default! }
 
   after { HoneycombRails.config.client.reset }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,8 @@ require File.dirname(__FILE__) + "/support/test_rails_app/app.rb"
 require 'libhoney'
 require 'rspec/rails'
 
+ENV['RACK_ENV'] ||= 'test'
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     # This option will default to `true` in RSpec 4. It makes the `description`

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,7 @@
+require File.dirname(__FILE__) + "/support/test_rails_app/app.rb"
+
 require 'libhoney'
+require 'rspec/rails'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|

--- a/spec/support/test_rails_app/app.rb
+++ b/spec/support/test_rails_app/app.rb
@@ -5,6 +5,8 @@ require 'honeycomb-rails'
 
 
 class TestApp < Rails::Application
+  # some minimal config Rails expects to be present
+  config.secret_key_base = 'test'
   config.eager_load = true
 
   routes.append do

--- a/spec/support/test_rails_app/app.rb
+++ b/spec/support/test_rails_app/app.rb
@@ -6,8 +6,12 @@ require 'honeycomb-rails'
 
 class TestApp < Rails::Application
   # some minimal config Rails expects to be present
-  config.secret_key_base = 'test'
-  config.secret_token = 'test' * 8
+  if Rails::VERSION::MAJOR < 4
+    config.secret_token = 'test' * 8
+  else
+    config.secret_key_base = 'test'
+  end
+
   config.eager_load = true
 
   routes.append do

--- a/spec/support/test_rails_app/app.rb
+++ b/spec/support/test_rails_app/app.rb
@@ -1,0 +1,34 @@
+require 'rails'
+require 'action_controller/railtie'
+
+require 'honeycomb-rails'
+
+
+class TestApp < Rails::Application
+  config.eager_load = true
+
+  routes.append do
+    get '/hello', to: 'hello#show'
+    get '/explode', to: 'hello#explode'
+  end
+
+  initializer :configure_honeycomb_rails do
+    HoneycombRails.configure do |config|
+      config.client = Libhoney::TestClient.new
+    end
+  end
+
+  # TODO shouldn't write log/development.log
+end
+
+class HelloController < ActionController::Base
+  class Explosion < RuntimeError; end
+
+  def show
+    render plain: 'Hello world!'
+  end
+
+  def explode
+    raise Explosion, 'kaboom!'
+  end
+end

--- a/spec/support/test_rails_app/app.rb
+++ b/spec/support/test_rails_app/app.rb
@@ -7,6 +7,7 @@ require 'honeycomb-rails'
 class TestApp < Rails::Application
   # some minimal config Rails expects to be present
   config.secret_key_base = 'test'
+  config.secret_token = 'test' * 8
   config.eager_load = true
 
   routes.append do
@@ -27,7 +28,11 @@ class HelloController < ActionController::Base
   class Explosion < RuntimeError; end
 
   def show
-    render plain: 'Hello world!'
+    if Rails::VERSION::MAJOR < 4
+      render text: 'Hello world!'
+    else
+      render plain: 'Hello world!'
+    end
   end
 
   def explode

--- a/spec/support/test_rails_app/app.rb
+++ b/spec/support/test_rails_app/app.rb
@@ -24,8 +24,6 @@ class TestApp < Rails::Application
       config.client = Libhoney::TestClient.new
     end
   end
-
-  # TODO shouldn't write log/development.log
 end
 
 class HelloController < ActionController::Base


### PR DESCRIPTION
This adds integration tests - we set up a minimal Rails app, install and configure the Railtie, fire some requests, and verify the right events were sent.

(This uses Rails' built-in integration testing support (via `rspec-rails`'s [request specs](https://relishapp.com/rspec/rspec-rails/docs/request-specs/request-spec)), so it bypasses the UI but otherwise exercises most of the stack in a fairly realistic way.)

Right now the tests are at the unit level, testing individual pieces of the integration. However, the stuff most likely to break - and therefore that we'd most like test coverage for - is how we hook those pieces into the Rails lifecycle, and how they interact. This is particularly true when we consider supporting multiple Rails versions - where a hook we depend on may not exist - or differently configured Rails apps, or interaction with other 3rd-party Rails plugins. It's also helpful to have these in place if we're reimplementing functionality via a different mechanism (such as #20).

This also asks TravisCI to run each build on multiple Rails versions (as well as multiple Ruby versions) - here's an [example build](https://travis-ci.org/honeycombio/honeycomb-rails/builds/368881599) confirming we support Rails 3, 4 and 5.

Resolves #1.