### PR TITLE
Support API-only controllers added in Rails 5

### DIFF
--- a/lib/honeycomb-rails/overrides/action_controller_instrumentation.rb
+++ b/lib/honeycomb-rails/overrides/action_controller_instrumentation.rb
@@ -11,7 +11,7 @@ module HoneycombRails
 
         metadata.merge!(honeycomb_user_metadata)
 
-        if HoneycombRails.config.record_flash?
+        if HoneycombRails.config.record_flash? && respond_to?(:flash)
           flash.each do |k, v|
             metadata[:"flash_#{k}"] = v
           end

--- a/lib/honeycomb-rails/railtie.rb
+++ b/lib/honeycomb-rails/railtie.rb
@@ -8,10 +8,18 @@ module HoneycombRails
   class Railtie < ::Rails::Railtie
     initializer 'honeycomb.action_controller_extensions', after: :action_controller do
       ::ActionController::Base.include(Extensions::ActionController::InstanceMethods)
+
+      if defined?(::ActionController::API) # Rails 5 and above
+        ::ActionController::API.include(Extensions::ActionController::InstanceMethods)
+      end
     end
 
     initializer 'honeycomb.action_controller_overrides', after: :action_controller do
       ::ActionController::Base.include(Overrides::ActionControllerInstrumentation)
+
+      if defined?(::ActionController::API) # Rails 5 and above
+        ::ActionController::API.include(Overrides::ActionControllerInstrumentation)
+      end
     end
 
     # set up libhoney after application initialization so that any config in

--- a/spec/support/test_rails_app/app.rb
+++ b/spec/support/test_rails_app/app.rb
@@ -17,6 +17,9 @@ class TestApp < Rails::Application
   routes.append do
     get '/hello', to: 'hello#show'
     get '/explode', to: 'hello#explode'
+
+    get '/api/hello', to: 'hello_api#show'
+    get '/api/explode', to: 'hello_api#explode'
   end
 
   initializer :configure_honeycomb_rails do
@@ -30,6 +33,8 @@ class HelloController < ActionController::Base
   class Explosion < RuntimeError; end
 
   def show
+    honeycomb_metadata[:greetee] = 'world'
+
     if Rails::VERSION::MAJOR < 4
       render text: 'Hello world!'
     else
@@ -39,5 +44,20 @@ class HelloController < ActionController::Base
 
   def explode
     raise Explosion, 'kaboom!'
+  end
+end
+
+if Rails::VERSION::MAJOR >= 5
+  class HelloApiController < ActionController::API
+    class Explosion < RuntimeError; end
+
+    def show
+      honeycomb_metadata[:greetee] = 'world'
+      render json: {status: 'ok', greeting: 'Hello world!'}
+    end
+
+    def explode
+      raise Explosion, 'kaboom!'
+    end
   end
 end


### PR DESCRIPTION
Rails 5 added official support for [API-only applications](https://guides.rubyonrails.org/5_0_release_notes.html#api-applications) and controllers (which previous versions of Rails supported only via third-party plugins). This PR extends honeycomb-rails to support them.

The only changes needed are to hook into `ActionController::API` as well as `ActionController::Base`, and to check for the existence of `#flash` before trying to record it (since `ActionController::API` does not have that method).

This should achieve the same goal as #25 (allowing customers to use honeycomb-rails for Rails API apps provided they are using Rails 5 or newer), but without impact to existing functionality.