### PR TITLE
Specify accurate `required_ruby_version` in gemspec

### DIFF
--- a/honeycomb-rails.gemspec
+++ b/honeycomb-rails.gemspec
@@ -30,9 +30,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'yard'
 
 
-  gem.required_ruby_version = '>= 2.0.0'
-
-
   gem.files = Dir[*%w(
       lib/**/*
       README*)] & %x{git ls-files -z}.split("\0")

--- a/honeycomb-rails.gemspec
+++ b/honeycomb-rails.gemspec
@@ -30,6 +30,9 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'yard'
 
 
+  gem.required_ruby_version = '>= 2.2.0'
+
+
   gem.files = Dir[*%w(
       lib/**/*
       README*)] & %x{git ls-files -z}.split("\0")


### PR DESCRIPTION
The actual minimum required Ruby version is 2.2, but that is enforced (in multiple places) by libhoney-rb anyway, so specifying it here too just creates a stale cache of that information. Removing it because it was confusing people.

We do want to duplicate that information in the docs, though - #27 notes the minimum requirements in the README so people don't have to rummage through the gemspec for it.