### PR TITLE
Ensure gemspec specifies libhoney >= 1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-gem 'libhoney', '>= 1.9'

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,4 @@ source 'https://rubygems.org'
 
 gemspec
 
-# pull in newer libhoney just for testing, since we need TestClient#reset
-gem 'libhoney', '>= 1.5.1'
+gem 'libhoney', '>= 1.9'

--- a/Gemfile.rails3.rb
+++ b/Gemfile.rails3.rb
@@ -2,7 +2,5 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'libhoney', '>= 1.9'
-
 gem 'rails', '< 4'
 gem 'test-unit', '~> 3.0'

--- a/Gemfile.rails3.rb
+++ b/Gemfile.rails3.rb
@@ -2,8 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-# pull in newer libhoney just for testing, since we need TestClient#reset
-gem 'libhoney', '>= 1.5.1'
+gem 'libhoney', '>= 1.9'
 
 gem 'rails', '< 4'
 gem 'test-unit', '~> 3.0'

--- a/Gemfile.rails4.rb
+++ b/Gemfile.rails4.rb
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-# pull in newer libhoney just for testing, since we need TestClient#reset
-gem 'libhoney', '>= 1.5.1'
+gem 'libhoney', '>= 1.9'
 
 gem 'rails', '< 5'

--- a/Gemfile.rails4.rb
+++ b/Gemfile.rails4.rb
@@ -2,6 +2,4 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'libhoney', '>= 1.9'
-
 gem 'rails', '< 5'

--- a/honeycomb-rails.gemspec
+++ b/honeycomb-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.license = 'MIT'
 
 
-  gem.add_dependency 'libhoney', '>= 1.8.1'
+  gem.add_dependency 'libhoney', '>= 1.9'
   gem.add_dependency 'rails', '>= 3.0.0'
 
   gem.add_development_dependency 'bump'


### PR DESCRIPTION
In order to ensure new users scoop up the performance benefits that come along with `libhoney 1.9+`